### PR TITLE
chore(deps): pnpm-workspace.yaml に minimumReleaseAge を追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# 悪意のあるリリースは1週間以内に発見され、レジストリから削除される為
+# config = 7 day x 24h x 60 min
+minimumReleaseAge: 10080


### PR DESCRIPTION
## 概要
- Issue #92 対応として `pnpm-workspace.yaml` を新規追加し、`minimumReleaseAge: 10080` を設定しました。
- 悪意のあるリリースを一定期間取り込まないための安全策を、Issue 記載のコメント付きで反映しました。
- 既存コードやロックファイルには影響しない最小変更です。

## 変更内容
- `pnpm-workspace.yaml` を追加
  - `minimumReleaseAge: 10080`
  - 設定意図を示すコメントを追加

## 動作確認
- `pnpm config get minimumReleaseAge --location=project` の結果が `10080` であることを確認

## 関連Issue
- Closes #92

Made with [Cursor](https://cursor.com)